### PR TITLE
Let original select visible to show any validation message from the browser

### DIFF
--- a/dist/js/jquery.prettydropdowns.js
+++ b/dist/js/jquery.prettydropdowns.js
@@ -58,6 +58,13 @@
         $select.data('size', nSize).removeAttr('size');
         // Set <select> height to reserve space for <div> container
         $select.css('visibility', 'hidden').outerHeight(oOptions.height);
+        // Let original select visible for a while to show any validation message from the browser
+        $select.on('invalid', function() {
+          $select.css('visibility', 'visible');
+          setTimeout(function() {
+            $select.css('visibility', 'hidden');
+          }, 5000);
+        });
         nTimestamp = performance.now()*100000000000000;
         // Test whether to add 'aria-labelledby'
         if (elSel.id) {


### PR DESCRIPTION
If an input field is required and the user does not supply a value, the form is not submitted and a tooltip is displayed stating the field is required. Given original selectbox is hidden, the user is not notified and the form doesn't submit, leaving the user confused.
This MR lets the original selectbox visible behind the prettydropdown for 5 seconds, so validation messages from the browser are shown.